### PR TITLE
Refactor README.md to reference App.jsx instead of App.js for ReactJS example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This example demonstrates how to use the resource navigator to filter Schedules 
     - [index.html](jQuery/src/index.html)
     - [index.js](jQuery/src/index.js)
 - **React**
-    - [App.js](React/src/App.js)
+    - [App.js](React/src/App.jsx)
 - **Vue**
     - [App.vue](Vue/src/App.vue)
 


### PR DESCRIPTION
I changed the reference App.jsx instead of App.js for the ReactJS example

`- [App.js](React/src/App.js)`
to
`- [App.js](React/src/App.jsx)`